### PR TITLE
Add machine_name column to CommandEvents

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_23_003840) do
+ActiveRecord::Schema.define(version: 2021_01_21_031931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2020_11_23_003840) do
     t.string "macos_version"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "machine_hardware_name"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Run `rails generate migration add_machine_name_to_command_event machine_hardware_name:string`
:shipit: 
The client is sending a parameter:

`machineHardwareName:x86_64` or `arm`
