### PR TITLE
Permit json params; Add missing migration

### DIFF
--- a/app/controllers/command_events_controller.rb
+++ b/app/controllers/command_events_controller.rb
@@ -75,7 +75,17 @@ class CommandEventsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def command_event_params
-      params.require(:command_event).permit(:name, :subcommand, :params, :duration, :client_id, :tuist_version, :swift_version, :macos_version)
+      params.require(:command_event).permit(
+        :name,
+        :subcommand,
+        :duration,
+        :client_id,
+        :tuist_version,
+        :swift_version,
+        :macos_version,
+        :machine_hardware_name,
+        params: {} # Allow any key inside the params JSON
+        )
     end
 
     def restrict_to_development

--- a/db/migrate/20201123003840_create_command_events.rb
+++ b/db/migrate/20201123003840_create_command_events.rb
@@ -11,7 +11,6 @@ class CreateCommandEvents < ActiveRecord::Migration[6.0]
       t.string :tuist_version
       t.string :swift_version
       t.string :macos_version
-
       t.timestamps
     end
   end

--- a/db/migrate/20210121031931_add_machine_name_to_command_event.rb
+++ b/db/migrate/20210121031931_add_machine_name_to_command_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMachineNameToCommandEvent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :command_events, :machine_hardware_name, :string
+  end
+end


### PR DESCRIPTION
1) `params` is a column of type JSON and thus it needs a special treatment in `permit` to whitelist custom keys inside the JSON, see this [SO thread](https://stackoverflow.com/questions/46849957/rails-5-1-json-parameter-is-permitted-but-still-prints-as-unpermitted-in-the-l)
2) Add missing migration